### PR TITLE
Introduce common API module

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,5 +20,4 @@ android {
 
 dependencies {
     implementation G.maven.android.appCompat
-    implementation G.maven.kotlin.stdlib
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'jacoco'
+apply plugin: PlaygroundPlugin
 
 android {
     applySdk()

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,6 @@ subprojects {
         mavenCentral()
         jcenter()
     }
-
-    apply plugin: PlaygroundPlugin
-    apply plugin: 'com.novoda.build-properties'
 }
 
 version = '1.0'

--- a/buildSrc/src/main/groovy/PlaygroundPlugin.groovy
+++ b/buildSrc/src/main/groovy/PlaygroundPlugin.groovy
@@ -2,6 +2,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import plugins.AndroidConfigurationPlugin
 import plugins.AndroidJacocoReportPlugin
+import plugins.KotlinConfigurationPlugin
 
 class PlaygroundPlugin implements Plugin<Project> {
 
@@ -9,5 +10,6 @@ class PlaygroundPlugin implements Plugin<Project> {
     void apply(Project project) {
         new AndroidConfigurationPlugin().apply(project)
         new AndroidJacocoReportPlugin().apply(project)
+        new KotlinConfigurationPlugin().apply(project)
     }
 }

--- a/buildSrc/src/main/groovy/PlaygroundPlugin.groovy
+++ b/buildSrc/src/main/groovy/PlaygroundPlugin.groovy
@@ -8,6 +8,7 @@ class PlaygroundPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        project.apply plugin: 'com.novoda.build-properties'
         new AndroidConfigurationPlugin().apply(project)
         new AndroidJacocoReportPlugin().apply(project)
         new KotlinConfigurationPlugin().apply(project)

--- a/buildSrc/src/main/groovy/plugins/AndroidConfigurationPlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/AndroidConfigurationPlugin.groovy
@@ -13,7 +13,6 @@ class AndroidConfigurationPlugin implements Plugin<Project> {
         project.plugins.withId('com.android.library') {
             addAndroidUtils(project.android, project.rootProject.version)
         }
-        addKotlinSourceSets(project)
     }
 
     private static void addAndroidUtils(android, version) {
@@ -27,14 +26,6 @@ class AndroidConfigurationPlugin implements Plugin<Project> {
                 targetSdkVersion 27
                 versionCode 1
                 versionName version
-            }
-        }
-    }
-
-    private static void addKotlinSourceSets(Project project) {
-        project.plugins.withId('kotlin-android') {
-            project.android.sourceSets.all { sourceSet ->
-                sourceSet.java.srcDirs += sourceSet.kotlin.srcDirs
             }
         }
     }

--- a/buildSrc/src/main/groovy/plugins/KotlinConfigurationPlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/KotlinConfigurationPlugin.groovy
@@ -1,0 +1,21 @@
+package plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class KotlinConfigurationPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.plugins.withId('kotlin-android') {
+            project.android.sourceSets.all { sourceSet ->
+                sourceSet.java.srcDirs += sourceSet.kotlin.srcDirs
+            }
+        }
+        project.plugins.withId('kotlin') {
+            project.sourceSets.all { sourceSet ->
+                sourceSet.java.srcDirs += sourceSet.kotlin.srcDirs
+            }
+        }
+    }
+}

--- a/features/common/api/build.gradle
+++ b/features/common/api/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'kotlin'
+apply plugin: PlaygroundPlugin
 
 dependencies {
     implementation G.maven.kotlin.stdlib

--- a/features/common/api/build.gradle
+++ b/features/common/api/build.gradle
@@ -2,13 +2,14 @@ apply plugin: 'kotlin'
 apply plugin: PlaygroundPlugin
 
 dependencies {
+    apiElements G.maven.moshi
+    apiElements G.maven.retrofit.core
+    apiElements G.maven.rxjava
+
     implementation G.maven.kotlin.stdlib
-    implementation G.maven.moshi
     implementation G.maven.okhttp
-    implementation G.maven.retrofit.core
     implementation G.maven.retrofit.moshi
     implementation G.maven.retrofit.rxjava
-    implementation G.maven.rxjava
 
     testImplementation G.maven.junit
     testImplementation G.maven.truth

--- a/features/common/api/build.gradle
+++ b/features/common/api/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'kotlin'
+
+dependencies {
+    implementation G.maven.kotlin.stdlib
+    implementation G.maven.moshi
+    implementation G.maven.okhttp
+    implementation G.maven.retrofit.core
+    implementation G.maven.retrofit.moshi
+    implementation G.maven.retrofit.rxjava
+    implementation G.maven.rxjava
+
+    testImplementation G.maven.junit
+    testImplementation G.maven.truth
+}

--- a/features/common/api/src/main/kotlin/io/archano/playground/common/api/RequestDecorator.kt
+++ b/features/common/api/src/main/kotlin/io/archano/playground/common/api/RequestDecorator.kt
@@ -1,10 +1,10 @@
-package com.letterboxd.authentication
+package io.archano.playground.common.api
 
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
 import okhttp3.Request
 
-internal interface RequestDecorator {
+interface RequestDecorator {
 
     fun decorate(request: Request): Request
 

--- a/features/common/api/src/main/kotlin/io/archano/playground/common/api/RetrofitConfiguration.kt
+++ b/features/common/api/src/main/kotlin/io/archano/playground/common/api/RetrofitConfiguration.kt
@@ -1,0 +1,46 @@
+package io.archano.playground.common.api
+
+import com.squareup.moshi.Moshi
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+class RetrofitConfiguration private constructor(
+        private val httpclient: OkHttpClient,
+        private val moshi: Moshi,
+        private val retrofit: Retrofit) {
+
+    fun <T> create(service: Class<T>): T {
+        return retrofit.create(service)
+    }
+
+    fun edit(): Builder {
+        return Builder(httpclient.newBuilder(), moshi.newBuilder(), retrofit.newBuilder())
+    }
+
+    class Builder constructor(private val httpClientBuilder: OkHttpClient.Builder,
+                              private val moshiBuilder: Moshi.Builder,
+                              private val retrofitBuilder: Retrofit.Builder) {
+
+        fun withNetworkInterceptor(interceptor: Interceptor): Builder {
+            httpClientBuilder.addInterceptor(interceptor)
+            return this
+        }
+
+        fun withBaseUrl(url: String): Builder {
+            retrofitBuilder.baseUrl(url)
+            return this
+        }
+
+        fun build(): RetrofitConfiguration {
+            val httpClient = httpClientBuilder.build()
+            val moshi = moshiBuilder.build()
+            val retrofit = retrofitBuilder
+                    .client(httpClient)
+                    .addConverterFactory(MoshiConverterFactory.create(moshi))
+                    .build()
+            return RetrofitConfiguration(httpClient, moshi, retrofit)
+        }
+    }
+}

--- a/features/letterboxd/api/build.gradle
+++ b/features/letterboxd/api/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'jacoco'
+apply plugin: PlaygroundPlugin
 
 buildProperties {
 

--- a/features/letterboxd/api/build.gradle
+++ b/features/letterboxd/api/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation G.maven.retrofit.moshi
     implementation G.maven.retrofit.rxjava
     implementation G.maven.rxjava
+    implementation project(':features:common:api')
 
     testImplementation G.maven.junit
     testImplementation G.maven.truth

--- a/features/letterboxd/api/build.gradle
+++ b/features/letterboxd/api/build.gradle
@@ -34,11 +34,7 @@ android {
 
 dependencies {
     implementation G.maven.kotlin.stdlib
-    implementation G.maven.moshi
-    implementation G.maven.okhttp
     implementation G.maven.retrofit.core
-    implementation G.maven.retrofit.moshi
-    implementation G.maven.retrofit.rxjava
     implementation G.maven.rxjava
     implementation project(':features:common:api')
 

--- a/features/letterboxd/api/build.gradle
+++ b/features/letterboxd/api/build.gradle
@@ -34,10 +34,9 @@ android {
 }
 
 dependencies {
+    api project(':features:common:api')
+
     implementation G.maven.kotlin.stdlib
-    implementation G.maven.retrofit.core
-    implementation G.maven.rxjava
-    implementation project(':features:common:api')
 
     testImplementation G.maven.junit
     testImplementation G.maven.truth

--- a/features/letterboxd/api/src/main/kotlin/com/letterboxd/authentication/RetrofitAccessTokenFetcher.kt
+++ b/features/letterboxd/api/src/main/kotlin/com/letterboxd/authentication/RetrofitAccessTokenFetcher.kt
@@ -1,13 +1,9 @@
 package com.letterboxd.authentication
 
 import com.letterboxd.BuildConfig
-import com.squareup.moshi.Moshi
+import io.archano.playground.common.api.RetrofitConfiguration
 import io.reactivex.Single
 import io.reactivex.functions.Function
-import okhttp3.OkHttpClient
-import retrofit2.Retrofit
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
-import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.Headers
@@ -23,19 +19,13 @@ internal class RetrofitAccessTokenFetcher private constructor(private val backen
 
     companion object {
 
-        fun create(): RetrofitAccessTokenFetcher {
+        fun create(configuration: RetrofitConfiguration): RetrofitAccessTokenFetcher {
             val urlRequestDecorator = UrlRequestDecorator.create(BuildConfig.API_KEY)
             val signingRequestDecorator = SignatureHeaderRequestDecorator(RequestSigner.create(BuildConfig.API_SECRET))
-            val okHttpClient: OkHttpClient = OkHttpClient.Builder()
-                    .addNetworkInterceptor(urlRequestDecorator.asInterceptor())
-                    .addNetworkInterceptor(signingRequestDecorator.asInterceptor())
-                    .build()
-            val backend = Retrofit.Builder()
-                    .baseUrl(LETTERBOX_BASE_URL)
-                    .client(okHttpClient)
-                    .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
-                    .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder().build()))
-                    .build()
+            val backend = configuration.newBuilder()
+                    .withRequestDecorator(urlRequestDecorator)
+                    .withRequestDecorator(signingRequestDecorator)
+                    .withBaseUrl(LETTERBOX_BASE_URL)
                     .create(AccessTokenBackend::class.java)
             return RetrofitAccessTokenFetcher(backend)
         }

--- a/features/letterboxd/api/src/main/kotlin/com/letterboxd/authentication/SignatureHeaderRequestDecorator.kt
+++ b/features/letterboxd/api/src/main/kotlin/com/letterboxd/authentication/SignatureHeaderRequestDecorator.kt
@@ -1,5 +1,6 @@
 package com.letterboxd.authentication
 
+import io.archano.playground.common.api.RequestDecorator
 import okhttp3.Request
 
 internal class SignatureHeaderRequestDecorator (private val signer: RequestSigner) : RequestDecorator {

--- a/features/letterboxd/api/src/main/kotlin/com/letterboxd/authentication/UrlRequestDecorator.kt
+++ b/features/letterboxd/api/src/main/kotlin/com/letterboxd/authentication/UrlRequestDecorator.kt
@@ -1,5 +1,6 @@
 package com.letterboxd.authentication
 
+import io.archano.playground.common.api.RequestDecorator
 import okhttp3.Request
 import java.util.*
 import java.util.concurrent.TimeUnit

--- a/features/letterboxd/api/src/test/kotlin/com/letterboxd/authentication/RetrofitAccessTokenFetcherTest.kt
+++ b/features/letterboxd/api/src/test/kotlin/com/letterboxd/authentication/RetrofitAccessTokenFetcherTest.kt
@@ -1,6 +1,7 @@
 package com.letterboxd.authentication
 
 import com.letterboxd.BuildConfig
+import io.archano.playground.common.api.RetrofitConfiguration
 import org.junit.Before
 import org.junit.Test
 
@@ -10,7 +11,7 @@ class RetrofitAccessTokenFetcherTest {
 
     @Before
     fun setUp() {
-        fetcher = RetrofitAccessTokenFetcher.create()
+        fetcher = RetrofitAccessTokenFetcher.create(RetrofitConfiguration())
     }
 
     @Test

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include ':app'
+include ':features:common:api'
 include ':features:letterboxd:api'


### PR DESCRIPTION
The new `features/common/api` module will contain all the common abstractions and utilities needed to configure Retrofit instances:
- `RetrofitConfiguration` is defined as abstraction over the configurable bits of a `Retrofit` instance, including any network interceptor, base url, etc (the API is still flowing)
- `RequestDecorator` is now part of this separated module, in order to allow the depending modules to work with an abstraction on top of the network interceptors
